### PR TITLE
Allow users to register custom events

### DIFF
--- a/app/jobs/solidus_klaviyo/track_event_job.rb
+++ b/app/jobs/solidus_klaviyo/track_event_job.rb
@@ -4,9 +4,12 @@ module SolidusKlaviyo
   class TrackEventJob < ApplicationJob
     queue_as :default
 
-    def perform(event_class, event_payload = {})
+    def perform(event_name, event_payload = {})
+      event_class = SolidusKlaviyo.configuration.events[event_name]
+      raise ArgumentError, "#{event_name} is not a registered Klaviyo event" unless event_class
+
       event_tracker = SolidusKlaviyo::EventTracker.new
-      event = "SolidusKlaviyo::Event::#{event_class.camelize}".constantize.new(event_payload)
+      event = event_class.new(event_payload)
 
       event_tracker.track(event)
     end

--- a/lib/generators/solidus_klaviyo/install/templates/initializer.rb
+++ b/lib/generators/solidus_klaviyo/install/templates/initializer.rb
@@ -12,7 +12,7 @@ SolidusKlaviyo.configure do |config|
   # A proc that accepts a variant and returns the URL of that variant's main image.
   config.image_url_builder = proc do |variant|
     image = variant.gallery.images.first
-    image.attachment.url(:product) if image
+    image&.attachment&.url(:product)
   end
 
   # You can register custom events or override the defaults by manipulating the `events` hash.

--- a/lib/generators/solidus_klaviyo/install/templates/initializer.rb
+++ b/lib/generators/solidus_klaviyo/install/templates/initializer.rb
@@ -14,4 +14,8 @@ SolidusKlaviyo.configure do |config|
     image = variant.gallery.images.first
     image.attachment.url(:product) if image
   end
+
+  # You can register custom events or override the defaults by manipulating the `events` hash.
+  # config.events['my_custom_event'] = MyApp::KlaviyoEvents::MyCustomEvent
+  # config.events['placed_order'] = MyApp::KlaviyoEvents::PlacedOrder
 end

--- a/lib/solidus_klaviyo/configuration.rb
+++ b/lib/solidus_klaviyo/configuration.rb
@@ -3,5 +3,13 @@
 module SolidusKlaviyo
   class Configuration
     attr_accessor :api_key, :variant_url_builder, :image_url_builder
+
+    def events
+      @events ||= {
+        'ordered_product' => SolidusKlaviyo::Event::OrderedProduct,
+        'placed_order' => SolidusKlaviyo::Event::PlacedOrder,
+        'started_checkout' => SolidusKlaviyo::Event::StartedCheckout,
+      }
+    end
   end
 end

--- a/spec/jobs/solidus_klaviyo/track_event_job_spec.rb
+++ b/spec/jobs/solidus_klaviyo/track_event_job_spec.rb
@@ -1,17 +1,41 @@
 # frozen_string_literal: true
 
 RSpec.describe SolidusKlaviyo::TrackEventJob do
-  it 'tracks the provided event via Klaviyo' do
-    order = build_stubbed(:order)
-    event_tracker = stub_event_tracker
-    event = stub_event(SolidusKlaviyo::Event::StartedCheckout, order: order)
+  context 'when the provided event is registered' do
+    it 'tracks the provided event via Klaviyo' do
+      stub_event_class('CustomEvent')
+      stub_custom_event('custom_event', CustomEvent)
+      event_tracker = stub_event_tracker
 
-    described_class.perform_now('started_checkout', order: order)
+      described_class.perform_now('custom_event', payload_key: 'payload_value')
 
-    expect(event_tracker).to have_received(:track).with(event)
+      expect(event_tracker).to have_received(:track).with(an_instance_of(CustomEvent))
+    end
+  end
+
+  context 'when the provided event is not registered' do
+    it 'raises an ArgumentError' do
+      expect {
+        described_class.perform_now('custom_event', payload_key: 'payload_value')
+      }.to raise_error(ArgumentError)
+    end
   end
 
   private
+
+  def stub_event_class(class_name)
+    stub_const(class_name, Class.new do
+      def initialize(payload = {})
+        @payload = payload
+      end
+    end)
+  end
+
+  def stub_custom_event(event_name, event_class)
+    allow(SolidusKlaviyo.configuration).to receive(:events).and_wrap_original do |original|
+      original.call.merge(event_name.to_s => event_class)
+    end
+  end
 
   def stub_event_tracker
     event_tracker = instance_spy(SolidusKlaviyo::EventTracker)
@@ -19,13 +43,5 @@ RSpec.describe SolidusKlaviyo::TrackEventJob do
     allow(SolidusKlaviyo::EventTracker).to receive(:new).and_return(event_tracker)
 
     event_tracker
-  end
-
-  def stub_event(event_klass, event_payload)
-    event = instance_double(event_klass)
-
-    allow(event_klass).to receive(:new).with(event_payload).and_return(event)
-
-    event
   end
 end

--- a/spec/solidus_klaviyo/configuration_spec.rb
+++ b/spec/solidus_klaviyo/configuration_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe SolidusKlaviyo::Configuration do
   it 'can be instantiated' do
     expect { described_class.new }.not_to raise_error
   end
+
+  it 'allows registering custom events' do
+    configuration = described_class.new
+
+    configuration.events['custom_event'] = OpenStruct
+
+    expect(configuration.events['custom_event']).to eq(OpenStruct)
+  end
 end


### PR DESCRIPTION
Implements an API that allows users to either register custom events or override the built-in events with their own implementation.