### PR TITLE
Allow skipping built-in emails

### DIFF
--- a/app/decorators/models/solidus_klaviyo/spree/order/disable_cancel_email.rb
+++ b/app/decorators/models/solidus_klaviyo/spree/order/disable_cancel_email.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  module Spree
+    module Order
+      module DisableCancelEmail
+        def send_cancel_email
+          super unless SolidusKlaviyo.configuration.disable_builtin_emails
+        end
+      end
+    end
+  end
+end
+
+Spree::Order.prepend(SolidusKlaviyo::Spree::Order::DisableCancelEmail)

--- a/app/decorators/models/solidus_klaviyo/spree/order/disable_confirm_email.rb
+++ b/app/decorators/models/solidus_klaviyo/spree/order/disable_confirm_email.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  module Spree
+    module Order
+      module DisableConfirmEmail
+        def deliver_order_confirmation_email
+          super unless SolidusKlaviyo.configuration.disable_builtin_emails
+        end
+      end
+    end
+  end
+end
+
+if Spree.solidus_gem_version < Gem::Version.new('2.9.0')
+  Spree::Order.prepend(SolidusKlaviyo::Spree::Order::DisableConfirmEmail)
+end

--- a/app/decorators/models/solidus_klaviyo/spree/user/disable_password_reset_email.rb
+++ b/app/decorators/models/solidus_klaviyo/spree/user/disable_password_reset_email.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  module Spree
+    module User
+      module DisablePasswordResetEmail
+        def send_reset_password_instructions_notification(token)
+          super unless SolidusKlaviyo.configuration.disable_builtin_emails
+        end
+      end
+    end
+  end
+end
+
+Spree.user_class.prepend(SolidusKlaviyo::Spree::User::DisablePasswordResetEmail)

--- a/app/decorators/subscribers/solidus_klaviyo/spree/mailer_subscriber/disable_confirm_email.rb
+++ b/app/decorators/subscribers/solidus_klaviyo/spree/mailer_subscriber/disable_confirm_email.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  module Spree
+    module MailerSubscriber
+      module DisableConfirmEmail
+        def self.prepended(base)
+          base.module_eval do
+            alias_method :original_order_finalized, :order_finalized
+
+            def order_finalized(event)
+              return if SolidusKlaviyo.configuration.disable_builtin_emails
+
+              original_order_finalized(event)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+if Spree.solidus_gem_version >= Gem::Version.new('2.9.0')
+  Spree::MailerSubscriber.prepend(SolidusKlaviyo::Spree::MailerSubscriber::DisableConfirmEmail)
+end

--- a/lib/generators/solidus_klaviyo/install/templates/initializer.rb
+++ b/lib/generators/solidus_klaviyo/install/templates/initializer.rb
@@ -38,6 +38,10 @@ SolidusKlaviyo.configure do |config|
     )
   end
 
+  # Disable the built-in emails for the provided Klaviyo events?
+  # This is useful if you'll send the transactional emails via Klaviyo flows instead.
+  config.disable_builtin_emails = false
+
   # A Klaviyo list that all users will be subscribed to when they sign up.
   # config.default_list = 'KLAVIYO_LIST_ID'
 

--- a/lib/solidus_klaviyo/configuration.rb
+++ b/lib/solidus_klaviyo/configuration.rb
@@ -4,8 +4,12 @@ module SolidusKlaviyo
   class Configuration
     attr_accessor(
       :api_key, :variant_url_builder, :image_url_builder, :default_list,
-      :password_reset_url_builder, :order_url_builder,
+      :password_reset_url_builder, :order_url_builder, :disable_builtin_emails,
     )
+
+    def initialize
+      @disable_builtin_emails = false
+    end
 
     def events
       @events ||= {

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -40,6 +40,28 @@ RSpec.describe Spree::Order do
         )
       end
     end
+
+    context 'when disable_builtin_emails is true' do
+      it 'does not send the confirmation email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(true)
+        order = Spree::TestingSupport::OrderWalkthrough.up_to(:payment)
+
+        expect {
+          order.complete!
+        }.not_to have_enqueued_email(Spree::OrderMailer, 'confirm_email')
+      end
+    end
+
+    context 'when disable_builtin_emails is false' do
+      it 'sends the confirmation email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(false)
+        order = Spree::TestingSupport::OrderWalkthrough.up_to(:payment)
+
+        expect {
+          order.complete!
+        }.to have_enqueued_email(Spree::OrderMailer, 'confirm_email')
+      end
+    end
   end
 
   describe '#canceled_by' do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -75,5 +75,27 @@ RSpec.describe Spree::Order do
         order: order,
       )
     end
+
+    context 'when disable_builtin_emails is true' do
+      it 'does not send the cancellation email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(true)
+        order = create(:completed_order_with_totals)
+
+        expect {
+          order.canceled_by(create(:user))
+        }.not_to have_enqueued_email(Spree::OrderMailer, 'cancel_email')
+      end
+    end
+
+    context 'when disable_builtin_emails is false' do
+      it 'sends the cancellation email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(false)
+        order = create(:completed_order_with_totals)
+
+        expect {
+          order.canceled_by(create(:user))
+        }.to have_enqueued_email(Spree::OrderMailer, 'cancel_email')
+      end
+    end
   end
 end

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -53,5 +53,33 @@ RSpec.describe Spree::User do
         token: an_instance_of(String),
       )
     end
+
+    context 'when disable_builtin_emails is true' do
+      it 'does not send the password reset email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(true)
+        email = instance_spy('ActionMailer::Delivery')
+        allow(Devise.mailer).to receive(:reset_password_instructions).and_return(email)
+        create(:store)
+        user = create(:user)
+
+        user.send_reset_password_instructions
+
+        expect(email).not_to have_received(:deliver_now)
+      end
+    end
+
+    context 'when disable_builtin_emails is false' do
+      it 'sends the password reset email' do
+        allow(SolidusKlaviyo.configuration).to receive(:disable_builtin_emails).and_return(false)
+        email = instance_spy('ActionMailer::Delivery')
+        allow(Devise.mailer).to receive(:reset_password_instructions).and_return(email)
+        create(:store)
+        user = create(:user)
+
+        user.send_reset_password_instructions
+
+        expect(email).to have_received(:deliver_now)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a configuration option that causes the extension to skip all built-in Solidus/Devise emails. This is useful in situations where the transactional emails are sent through Klaviyo flows rather than using the built-in mailers.

The following emails are disabled:

- Order confirmation email (covered by the Placed Order event)
- Order cancellation email (covered by the Canceled Order event)
- Password reset email (covered by the Reset Password event)