### PR TITLE
Implement top-level APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ If you want to subscribe a user to a Klaviyo list, the extension provides a hand
 that:
 
 ```ruby
-subscriber = SolidusKlaviyo::Subscriber.new('YOUR_LIST_ID')
-subscriber.subscribe('jdoe@example.com') # => true or raises SolidusKlaviyo::Subscriber::SubscriptionError 
+SolidusKlaviyo.subscribe_now('YOUR_LIST_ID', 'jdoe@example.com', custom_property: 'value') 
 ```
 
 We recommend using the built-in background job to subscribe users, in order to avoid blocking your
 web workers and slowing down the customer:
 
 ```ruby
-SolidusKlaviyo::SubscribeJob.perform_later('YOUR_LIST_ID', 'jdoe@example.com')
+SolidusKlaviyo.subscribe_later('YOUR_LIST_ID', 'jdoe@example.com', custom_property: 'value')
 ```
 
 #### Subscribing all users upon signup

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 Your custom event is now properly configured! You can track it by enqueuing the `TrackEventJob`:
 
 ```ruby
-SolidusKlaviyo::TrackEventJob.perform_later('signed_up', user: user)
+SolidusKlaviyo.track_later('signed_up', user: user)
 ```
 
 *NOTE:* You can follow the same exact pattern to override the built-in events.

--- a/app/jobs/solidus_klaviyo/subscribe_job.rb
+++ b/app/jobs/solidus_klaviyo/subscribe_job.rb
@@ -5,7 +5,7 @@ module SolidusKlaviyo
     queue_as :default
 
     def perform(list_id, email, properties = {})
-      SolidusKlaviyo::Subscriber.new(list_id).subscribe(email, properties)
+      SolidusKlaviyo.subscribe_now(list_id, email, properties)
     end
   end
 end

--- a/app/jobs/solidus_klaviyo/track_event_job.rb
+++ b/app/jobs/solidus_klaviyo/track_event_job.rb
@@ -5,13 +5,7 @@ module SolidusKlaviyo
     queue_as :default
 
     def perform(event_name, event_payload = {})
-      event_class = SolidusKlaviyo.configuration.events[event_name]
-      raise ArgumentError, "#{event_name} is not a registered Klaviyo event" unless event_class
-
-      event_tracker = SolidusKlaviyo::EventTracker.new
-      event = event_class.new(event_payload)
-
-      event_tracker.track(event)
+      SolidusKlaviyo.track_now(event_name, event_payload)
     end
   end
 end

--- a/lib/solidus_klaviyo.rb
+++ b/lib/solidus_klaviyo.rb
@@ -48,5 +48,13 @@ module SolidusKlaviyo
       configuration.event_klass!(event_name) # validate event name
       SolidusKlaviyo::TrackEventJob.perform_later(event_name, event_payload)
     end
+
+    def subscribe_now(list_id, email, properties = {})
+      Subscriber.new(list_id).subscribe(email, properties)
+    end
+
+    def subscribe_later(list_id, email, properties = {})
+      SubscribeJob.perform_later(list_id, email, properties)
+    end
   end
 end

--- a/lib/solidus_klaviyo.rb
+++ b/lib/solidus_klaviyo.rb
@@ -27,6 +27,7 @@ require 'solidus_klaviyo/event/cancelled_order'
 require 'solidus_klaviyo/event/reset_password'
 require 'solidus_klaviyo/event/created_account'
 require 'solidus_klaviyo/subscriber'
+require 'solidus_klaviyo/errors'
 
 module SolidusKlaviyo
   class << self
@@ -36,6 +37,16 @@ module SolidusKlaviyo
 
     def configure
       yield configuration
+    end
+
+    def track_now(event_name, event_payload = {})
+      event = configuration.event_klass!(event_name).new(event_payload)
+      EventTracker.new.track(event)
+    end
+
+    def track_later(event_name, event_payload = {})
+      configuration.event_klass!(event_name) # validate event name
+      SolidusKlaviyo::TrackEventJob.perform_later(event_name, event_payload)
     end
   end
 end

--- a/lib/solidus_klaviyo/configuration.rb
+++ b/lib/solidus_klaviyo/configuration.rb
@@ -21,5 +21,13 @@ module SolidusKlaviyo
         'created_account' => SolidusKlaviyo::Event::CreatedAccount,
       }
     end
+
+    def event_klass(name)
+      events[name.to_s]
+    end
+
+    def event_klass!(name)
+      event_klass(name) || raise(UnregisteredEventError, name)
+    end
   end
 end

--- a/lib/solidus_klaviyo/errors.rb
+++ b/lib/solidus_klaviyo/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  class UnregisteredEventError < ArgumentError
+    def initialize(event_name, *args)
+      super("#{event_name} is not a registered Klaviyo event", *args)
+    end
+  end
+end

--- a/lib/solidus_klaviyo/errors.rb
+++ b/lib/solidus_klaviyo/errors.rb
@@ -6,4 +6,6 @@ module SolidusKlaviyo
       super("#{event_name} is not a registered Klaviyo event", *args)
     end
   end
+
+  class SubscriptionError < RuntimeError; end
 end

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -2,8 +2,6 @@
 
 module SolidusKlaviyo
   class Subscriber
-    class SubscriptionError < RuntimeError; end
-
     attr_reader :list_id
 
     def initialize(list_id)

--- a/spec/jobs/solidus_klaviyo/subscribe_job_spec.rb
+++ b/spec/jobs/solidus_klaviyo/subscribe_job_spec.rb
@@ -2,14 +2,15 @@
 
 RSpec.describe SolidusKlaviyo::SubscribeJob do
   it 'subscribes the given email to the given list' do
-    subscriber = instance_spy(SolidusKlaviyo::Subscriber)
-    list_id = 'dummyListId'
-    allow(SolidusKlaviyo::Subscriber).to receive(:new).with(list_id).and_return(subscriber)
+    solidus_klaviyo = class_spy(SolidusKlaviyo)
+    stub_const('SolidusKlaviyo', solidus_klaviyo)
 
-    email = 'jdoe@example.com'
-    properties = { 'first_name' => 'John' }
-    described_class.perform_now(list_id, email, properties)
+    described_class.perform_now('dummyListId', 'jdoe@example.com', first_name: 'John')
 
-    expect(subscriber).to have_received(:subscribe).with(email, properties)
+    expect(solidus_klaviyo).to have_received(:subscribe_now).with(
+      'dummyListId',
+      'jdoe@example.com',
+      first_name: 'John',
+    )
   end
 end

--- a/spec/jobs/solidus_klaviyo/track_event_job_spec.rb
+++ b/spec/jobs/solidus_klaviyo/track_event_job_spec.rb
@@ -1,47 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe SolidusKlaviyo::TrackEventJob do
-  context 'when the provided event is registered' do
-    it 'tracks the provided event via Klaviyo' do
-      stub_event_class('CustomEvent')
-      stub_custom_event('custom_event', CustomEvent)
-      event_tracker = stub_event_tracker
+  it 'tracks the event' do
+    solidus_klaviyo = class_spy(SolidusKlaviyo)
+    stub_const('SolidusKlaviyo', solidus_klaviyo)
 
-      described_class.perform_now('custom_event', payload_key: 'payload_value')
+    described_class.perform_now('custom_event', payload_key: 'value')
 
-      expect(event_tracker).to have_received(:track).with(an_instance_of(CustomEvent))
-    end
-  end
-
-  context 'when the provided event is not registered' do
-    it 'raises an ArgumentError' do
-      expect {
-        described_class.perform_now('custom_event', payload_key: 'payload_value')
-      }.to raise_error(ArgumentError)
-    end
-  end
-
-  private
-
-  def stub_event_class(class_name)
-    stub_const(class_name, Class.new do
-      def initialize(payload = {})
-        @payload = payload
-      end
-    end)
-  end
-
-  def stub_custom_event(event_name, event_class)
-    allow(SolidusKlaviyo.configuration).to receive(:events).and_wrap_original do |original|
-      original.call.merge(event_name.to_s => event_class)
-    end
-  end
-
-  def stub_event_tracker
-    event_tracker = instance_spy(SolidusKlaviyo::EventTracker)
-
-    allow(SolidusKlaviyo::EventTracker).to receive(:new).and_return(event_tracker)
-
-    event_tracker
+    expect(solidus_klaviyo).to have_received(:track_now).with('custom_event', payload_key: 'value')
   end
 end

--- a/spec/solidus_klaviyo/configuration_spec.rb
+++ b/spec/solidus_klaviyo/configuration_spec.rb
@@ -12,4 +12,46 @@ RSpec.describe SolidusKlaviyo::Configuration do
 
     expect(configuration.events['custom_event']).to eq(OpenStruct)
   end
+
+  describe '#event_klass' do
+    context 'when the event is registered' do
+      it 'returns the class for the event' do
+        configuration = described_class.new
+
+        configuration.events['custom_event'] = OpenStruct
+
+        expect(configuration.event_klass(:custom_event)).to eq(OpenStruct)
+      end
+    end
+
+    context 'when the event is not registered' do
+      it 'returns nil' do
+        configuration = described_class.new
+
+        expect(configuration.event_klass(:custom_event)).to be_nil
+      end
+    end
+  end
+
+  describe '#event_klass!' do
+    context 'when the event is registered' do
+      it 'returns the class for the event' do
+        configuration = described_class.new
+
+        configuration.events['custom_event'] = OpenStruct
+
+        expect(configuration.event_klass!(:custom_event)).to eq(OpenStruct)
+      end
+    end
+
+    context 'when the event is not registered' do
+      it 'raises an UnregisteredEventError' do
+        configuration = described_class.new
+
+        expect {
+          configuration.event_klass!(:custom_event)
+        }.to raise_error(SolidusKlaviyo::UnregisteredEventError)
+      end
+    end
+  end
 end

--- a/spec/solidus_klaviyo/subscriber_spec.rb
+++ b/spec/solidus_klaviyo/subscriber_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SolidusKlaviyo::Subscriber do
           email = 'jdoe@example.com'
           expect {
             subscriber.subscribe(email)
-          }.to raise_error(described_class::SubscriptionError)
+          }.to raise_error(SolidusKlaviyo::SubscriptionError)
         end
       end
     end

--- a/spec/solidus_klaviyo_spec.rb
+++ b/spec/solidus_klaviyo_spec.rb
@@ -71,4 +71,27 @@ RSpec.describe SolidusKlaviyo do
       end
     end
   end
+
+  describe '.subscribe_now' do
+    it 'subscribes the profile to the given list' do
+      subscriber = instance_spy(SolidusKlaviyo::Subscriber)
+      allow(SolidusKlaviyo::Subscriber).to receive(:new).with('fakeList').and_return(subscriber)
+
+      described_class.subscribe_now('fakeList', 'jdoe@example.com', property: 'value')
+
+      expect(subscriber).to have_received(:subscribe).with('jdoe@example.com', property: 'value')
+    end
+  end
+
+  describe '.subscribe_later' do
+    it 'enqueues a SubscribeJob' do
+      described_class.subscribe_later('fakeList', 'jdoe@example.com', property: 'value')
+
+      expect(SolidusKlaviyo::SubscribeJob).to have_been_enqueued.with(
+        'fakeList',
+        'jdoe@example.com',
+        property: 'value',
+      )
+    end
+  end
 end


### PR DESCRIPTION
These APIs make are easier to stub in the applications that use them and reduce the chance for error by creating a standardized API for interacting with the extension, rather than relying on the user knowing its internals.