### PR TITLE
Test mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ require:
 RSpec/DescribeClass:
   Exclude:
     - spec/integration/**/*
+
+RSpec/NestedGroups:
+  Max: 4

--- a/README.md
+++ b/README.md
@@ -164,6 +164,30 @@ end
 ```
 
 This spares you the need to use VCR and similar.
+ 
+When in test mode, you can also use our custom RSpec matchers to check if a profile has been
+subscribed or an event has been tracked:
+
+```ruby
+require 'solidus_klaviyo/testing_support/matchers'
+
+RSpec.describe 'My Klaviyo integration' do
+  it 'subscribes users' do
+    SolidusKlaviyo.subscribe_now 'my_list_id', 'jdoe@example.com', full_name: 'John Doe'
+
+    expect(SolidusKlaviyo).to have_subscribed('jdoe@example.com')
+      .to('my_list_id')
+      .with(full_name: 'John Doe')
+  end
+
+  it 'tracks events' do
+    SolidsuKlaviyo.track_now 'custom_event', foo: 'bar'
+
+    expect(SolidusKlaviyo).to have_tracked_event(CustomEvent)
+      .with(foo: 'bar')
+  end
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ This will disable the following emails:
 
 You'll have to re-implement the emails with Klaviyo.
 
+### Test mode
+
+You can enable test mode to mock all API calls instead of performing them:
+
+```ruby
+# config/initializers/solidus_klaviyo.rb
+SolidusKlaviyo.configure do |config|
+  config.test_mode = true
+end
+```
+
+This spares you the need to use VCR and similar.
+
 ## Development
 
 ### Testing the extension

--- a/lib/generators/solidus_klaviyo/install/templates/initializer.rb
+++ b/lib/generators/solidus_klaviyo/install/templates/initializer.rb
@@ -48,4 +48,8 @@ SolidusKlaviyo.configure do |config|
   # You can register custom events or override the defaults by manipulating the `events` hash.
   # config.events['my_custom_event'] = MyApp::KlaviyoEvents::MyCustomEvent
   # config.events['placed_order'] = MyApp::KlaviyoEvents::PlacedOrder
+
+  # In test mode, all calls to `#track_now` and `#subscribe_now` are recorded and their
+  # responses are mocked.
+  config.test_mode = false
 end

--- a/lib/solidus_klaviyo.rb
+++ b/lib/solidus_klaviyo.rb
@@ -28,9 +28,12 @@ require 'solidus_klaviyo/event/reset_password'
 require 'solidus_klaviyo/event/created_account'
 require 'solidus_klaviyo/subscriber'
 require 'solidus_klaviyo/errors'
+require 'solidus_klaviyo/testing_support/test_registry'
 
 module SolidusKlaviyo
   class << self
+    delegate :tracked_events, :subscribed_profiles, to: :test_registry
+
     def configuration
       @configuration ||= Configuration.new
     end
@@ -55,6 +58,12 @@ module SolidusKlaviyo
 
     def subscribe_later(list_id, email, properties = {})
       SubscribeJob.perform_later(list_id, email, properties)
+    end
+
+    private
+
+    def test_registry
+      @test_registry ||= TestingSupport::TestRegistry.new
     end
   end
 end

--- a/lib/solidus_klaviyo/configuration.rb
+++ b/lib/solidus_klaviyo/configuration.rb
@@ -5,6 +5,7 @@ module SolidusKlaviyo
     attr_accessor(
       :api_key, :variant_url_builder, :image_url_builder, :default_list,
       :password_reset_url_builder, :order_url_builder, :disable_builtin_emails,
+      :test_mode,
     )
 
     def initialize

--- a/lib/solidus_klaviyo/event_tracker.rb
+++ b/lib/solidus_klaviyo/event_tracker.rb
@@ -7,13 +7,18 @@ module SolidusKlaviyo
     end
 
     def track(event)
-      klaviyo.track(
-        event.name,
-        email: event.email,
-        customer_properties: event.customer_properties,
-        properties: event.properties,
-        time: event.time,
-      )
+      if SolidusKlaviyo.configuration.test_mode
+        SolidusKlaviyo.tracked_events << event
+        true
+      else
+        klaviyo.track(
+          event.name,
+          email: event.email,
+          customer_properties: event.customer_properties,
+          properties: event.properties,
+          time: event.time,
+        )
+      end
     end
 
     private

--- a/lib/solidus_klaviyo/subscriber.rb
+++ b/lib/solidus_klaviyo/subscriber.rb
@@ -9,19 +9,29 @@ module SolidusKlaviyo
     end
 
     def subscribe(email, properties = {})
-      response = HTTParty.post(
-        "https://a.klaviyo.com/api/v2/list/#{list_id}/subscribe",
-        body: {
-          api_key: SolidusKlaviyo.configuration.api_key,
-          profiles: [properties.merge('email' => email)],
-        }.to_json,
-        headers: {
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json',
+      if SolidusKlaviyo.configuration.test_mode
+        SolidusKlaviyo.subscribed_profiles << {
+          list_id: list_id,
+          email: email,
+          properties: properties,
         }
-      )
 
-      response.success? || raise(SubscriptionError, response.parsed_response['detail'])
+        true
+      else
+        response = HTTParty.post(
+          "https://a.klaviyo.com/api/v2/list/#{list_id}/subscribe",
+          body: {
+            api_key: SolidusKlaviyo.configuration.api_key,
+            profiles: [properties.merge('email' => email)],
+          }.to_json,
+          headers: {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+          }
+        )
+
+        response.success? || raise(SubscriptionError, response.parsed_response['detail'])
+      end
     end
   end
 end

--- a/lib/solidus_klaviyo/testing_support/matchers.rb
+++ b/lib/solidus_klaviyo/testing_support/matchers.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+module SolidusKlaviyo
+  module TestingSupport
+    module Matchers
+      extend RSpec::Matchers::DSL
+
+      matcher :have_tracked do |klass|
+        match do |actual|
+          actual.tracked_events.any? do |event|
+            event.is_a?(klass) &&
+              (!@payload || values_match?(@payload, event.payload))
+          end
+        end
+
+        chain :with do |payload|
+          @payload = payload
+        end
+      end
+
+      matcher :have_subscribed do |email|
+        match do |actual|
+          actual.subscribed_profiles.any? do |profile|
+            values_match?(email, profile[:email]) &&
+              (!@list_id || values_match?(@list_id, profile[:list_id])) &&
+              (!@properties || values_match?(@properties, profile[:properties]))
+          end
+        end
+
+        chain :to do |list_id|
+          @list_id = list_id
+        end
+
+        chain :with do |properties|
+          @properties = properties
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include SolidusKlaviyo::TestingSupport::Matchers
+end

--- a/lib/solidus_klaviyo/testing_support/test_registry.rb
+++ b/lib/solidus_klaviyo/testing_support/test_registry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusKlaviyo
+  module TestingSupport
+    class TestRegistry
+      def tracked_events
+        @tracked_events ||= []
+      end
+
+      def subscribed_profiles
+        @subscribed_profiles ||= []
+      end
+    end
+  end
+end

--- a/spec/solidus_klaviyo/event_tracker_spec.rb
+++ b/spec/solidus_klaviyo/event_tracker_spec.rb
@@ -2,28 +2,42 @@
 
 RSpec.describe SolidusKlaviyo::EventTracker do
   describe '#track' do
-    it 'tracks the event through the Klaviyo API' do
-      klaviyo_client = stub_klaviyo_client
-      time = Time.zone.now
-      event = instance_double(
-        SolidusKlaviyo::Event::StartedCheckout,
-        name: 'Started Checkout',
-        email: 'jdoe@example.com',
-        customer_properties: { '$email' => 'jdoe@example.com' },
-        properties: { 'foo' => 'bar' },
-        time: time,
-      )
+    context 'when test_mode is enabled' do
+      it 'adds the event to the test registry' do
+        allow(SolidusKlaviyo.configuration).to receive(:test_mode).and_return(true)
+        event = instance_double(SolidusKlaviyo::Event::StartedCheckout)
 
-      event_tracker = described_class.new
-      event_tracker.track(event)
+        event_tracker = described_class.new
+        event_tracker.track(event)
 
-      expect(klaviyo_client).to have_received(:track).with(
-        'Started Checkout',
-        email: 'jdoe@example.com',
-        customer_properties: { '$email' => 'jdoe@example.com' },
-        properties: { 'foo' => 'bar' },
-        time: time,
-      )
+        expect(SolidusKlaviyo.tracked_events).to include(event)
+      end
+    end
+
+    context 'when test_mode is disabled' do
+      it 'tracks the event through the Klaviyo API' do
+        klaviyo_client = stub_klaviyo_client
+        time = Time.zone.now
+        event = instance_double(
+          SolidusKlaviyo::Event::StartedCheckout,
+          name: 'Started Checkout',
+          email: 'jdoe@example.com',
+          customer_properties: { '$email' => 'jdoe@example.com' },
+          properties: { 'foo' => 'bar' },
+          time: time,
+        )
+
+        event_tracker = described_class.new
+        event_tracker.track(event)
+
+        expect(klaviyo_client).to have_received(:track).with(
+          'Started Checkout',
+          email: 'jdoe@example.com',
+          customer_properties: { '$email' => 'jdoe@example.com' },
+          properties: { 'foo' => 'bar' },
+          time: time,
+        )
+      end
     end
   end
 

--- a/spec/solidus_klaviyo/subscriber_spec.rb
+++ b/spec/solidus_klaviyo/subscriber_spec.rb
@@ -2,32 +2,51 @@
 
 RSpec.describe SolidusKlaviyo::Subscriber do
   describe '#subscribe' do
-    context 'when the request is well-formed' do
-      it 'subscribes the given email to the configured list' do
+    context 'when test_mode is enabled' do
+      it 'adds the profile to the test registry' do
+        allow(SolidusKlaviyo.configuration).to receive(:test_mode).and_return(true)
         list_id = 'dummyListId'
         subscriber = described_class.new(list_id)
 
-        VCR.use_cassette('subscriber') do
-          email = 'jdoe@example.com'
-          subscriber.subscribe(email)
-        end
+        email = 'jdoe@example.com'
+        subscriber.subscribe(email)
 
-        expect(
-          a_request(:post, "https://a.klaviyo.com/api/v2/list/#{list_id}/subscribe")
-        ).to have_been_made
+        expect(SolidusKlaviyo.subscribed_profiles).to include(
+          list_id: list_id,
+          email: email,
+          properties: {},
+        )
       end
     end
 
-    context 'when the request is malformed' do
-      it 'raises a SubscriptionError' do
-        list_id = 'wrongListId'
-        subscriber = described_class.new(list_id)
+    context 'when test_mode is disabled' do
+      context 'when the request is well-formed' do
+        it 'subscribes the given email to the configured list' do
+          list_id = 'dummyListId'
+          subscriber = described_class.new(list_id)
 
-        VCR.use_cassette('subscriber') do
-          email = 'jdoe@example.com'
-          expect {
+          VCR.use_cassette('subscriber') do
+            email = 'jdoe@example.com'
             subscriber.subscribe(email)
-          }.to raise_error(SolidusKlaviyo::SubscriptionError)
+          end
+
+          expect(
+            a_request(:post, "https://a.klaviyo.com/api/v2/list/#{list_id}/subscribe")
+          ).to have_been_made
+        end
+      end
+
+      context 'when the request is malformed' do
+        it 'raises a SubscriptionError' do
+          list_id = 'wrongListId'
+          subscriber = described_class.new(list_id)
+
+          VCR.use_cassette('subscriber') do
+            email = 'jdoe@example.com'
+            expect {
+              subscriber.subscribe(email)
+            }.to raise_error(SolidusKlaviyo::SubscriptionError)
+          end
         end
       end
     end

--- a/spec/solidus_klaviyo/testing_support/matchers_spec.rb
+++ b/spec/solidus_klaviyo/testing_support/matchers_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'solidus_klaviyo/testing_support/matchers'
+
+RSpec.describe SolidusKlaviyo::TestingSupport::Matchers do
+  describe '.have_tracked' do
+    it 'matches when the event was tracked' do
+      test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+      test_registry.tracked_events << SolidusKlaviyo::Event::StartedCheckout.new
+
+      expect(test_registry).to have_tracked(SolidusKlaviyo::Event::StartedCheckout)
+    end
+
+    it 'fails when the event was not tracked' do
+      test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+      test_registry.tracked_events << SolidusKlaviyo::Event::PlacedOrder.new
+
+      expect(test_registry).not_to have_tracked(SolidusKlaviyo::Event::StartedCheckout)
+    end
+
+    describe '.with' do
+      it 'matches when the event was tracked with the right payload' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.tracked_events << SolidusKlaviyo::Event::StartedCheckout.new(foo: 'bar')
+
+        expect(test_registry).to have_tracked(SolidusKlaviyo::Event::StartedCheckout)
+          .with(foo: 'bar')
+      end
+
+      it 'fails when the event was tracked with the wrong payload' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.tracked_events << SolidusKlaviyo::Event::StartedCheckout.new(foo: 'baz')
+
+        expect(test_registry).not_to have_tracked(SolidusKlaviyo::Event::StartedCheckout)
+          .with(foo: 'bar')
+      end
+    end
+  end
+
+  describe '.have_subscribed' do
+    it 'matches when the email was subscribed' do
+      test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+      test_registry.subscribed_profiles << { email: 'jdoe@example.com' }
+
+      expect(test_registry).to have_subscribed('jdoe@example.com')
+    end
+
+    it 'fails when the email was not subscribed' do
+      test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+      test_registry.subscribed_profiles << { email: 'foo@example.com' }
+
+      expect(test_registry).not_to have_subscribed('jdoe@example.com')
+    end
+
+    describe '.to' do
+      it 'matches when the email was subscribed to the right list' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.subscribed_profiles << { email: 'jdoe@example.com', list_id: 'dummyList' }
+
+        expect(test_registry).to have_subscribed('jdoe@example.com').to('dummyList')
+      end
+
+      it 'fails when the email was subscribed to the wrong list' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.subscribed_profiles << { email: 'jdoe@example.com', list_id: 'wrongList' }
+
+        expect(test_registry).not_to have_subscribed('jdoe@example.com').to('dummyList')
+      end
+    end
+
+    describe '.with' do
+      it 'matches when the email was subscribed with the right properties' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.subscribed_profiles << {
+          email: 'jdoe@example.com',
+          properties: { foo: 'bar' },
+        }
+
+        expect(test_registry).to have_subscribed('jdoe@example.com').with(foo: 'bar')
+      end
+
+      it 'fails when the email was subscribed with the wrong properties' do
+        test_registry = SolidusKlaviyo::TestingSupport::TestRegistry.new
+        test_registry.subscribed_profiles << {
+          email: 'jdoe@example.com',
+          properties: { foo: 'baz' },
+        }
+
+        expect(test_registry).not_to have_subscribed('jdoe@example.com').with(foo: 'bar')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a test mode that records track and subscribe calls instead of executing them. Also includes custom RSpec matchers to verify that the calls have been made.